### PR TITLE
Refactor player resume logic and update @prisma/client to 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "url": "https://github.com/Ganyu-Studios/stelle-music/issues"
     },
     "dependencies": {
-        "@prisma/client": "^5.22.0",
+        "@prisma/client": "^6.0.1",
         "lavalink-client": "^2.4.1",
         "meowdb": "^2.2.3",
         "seyfert": "github:tiramisulabs/seyfert",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@prisma/client':
-        specifier: ^5.22.0
-        version: 5.22.0(prisma@5.22.0)
+        specifier: ^6.0.1
+        version: 6.0.1(prisma@5.22.0)
       lavalink-client:
         specifier: ^2.4.1
         version: 2.4.1
@@ -245,9 +245,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@prisma/client@5.22.0':
-    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
-    engines: {node: '>=16.13'}
+  '@prisma/client@6.0.1':
+    resolution: {integrity: sha512-60w7kL6bUxz7M6Gs/V+OWMhwy94FshpngVmOY05TmGD0Lhk+Ac0ZgtjlL6Wll9TD4G03t4Sq1wZekNVy+Xdlbg==}
+    engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
     peerDependenciesMeta:
@@ -671,7 +671,7 @@ snapshots:
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
-  '@prisma/client@5.22.0(prisma@5.22.0)':
+  '@prisma/client@6.0.1(prisma@5.22.0)':
     optionalDependencies:
       prisma: 5.22.0
 

--- a/src/lavalink/player/resumed.ts
+++ b/src/lavalink/player/resumed.ts
@@ -34,20 +34,21 @@ export default new Lavalink({
 
                 await player.connect();
 
-                player.filterManager.data = data.filters;
+                Object.assign(player.filterManager, { data: data.filters });
                 player.repeatMode = session.repeatMode;
 
                 if (data.track) player.queue.current = client.manager.utils.buildTrack(data.track, session.me);
-
                 if (!player.queue.previous.length) player.queue.previous.unshift(...session.queue!.previous);
                 if (!player.queue.tracks.length) player.queue.add(session.queue!.tracks);
 
-                player.lastPosition = data.state.position;
-                player.lastPositionChange = Date.now();
-                player.ping.lavalink = data.state.ping;
+                Object.assign(player, {
+                    lastPosition: data.state.position,
+                    lastPositionChange: Date.now(),
+                    paused: data.paused,
+                    playing: !data.paused && !!data.track,
+                });
 
-                player.paused = data.paused;
-                player.playing = !data.paused && !!data.track;
+                player.ping.lavalink = data.state.ping;
 
                 await player.queue.utils.save();
             } else {


### PR DESCRIPTION
- **Refactored** the player resume logic to improve readability, reduce redundancy, and simplify property handling while maintaining the same functionality.  
- **Updated** `@prisma/client` dependency from version `^5.22.0` to `^6.0.1`