### PR TITLE
fix(MoveCommand): added player.setVoice to sync with the voiceState and connect correctly to voice channel

### DIFF
--- a/src/commands/music/move.ts
+++ b/src/commands/music/move.ts
@@ -54,7 +54,8 @@ export default class MoveCommand extends Command {
         player.voiceId = voice.id;
 
         const textId: string = text?.id ?? player.textId ?? player.options.textId ?? ctx.channelId;
-
+        
+        await player.setVoice({ voiceId: voice.id })
         await player.connect();
         await ctx.editOrReply({
             embeds: [


### PR DESCRIPTION
After this code base updated to Hoshimi there was a issue in move command, which voiceState wasn't updating and bot isn't connecting to new voice channel so the fix was simple just add the player.setVoice function before connecting so the voiceState will also change to the new voice channel and bot will connect correctly