### PR TITLE
feat(247): work without an active player and autoreconnect on kick

### DIFF
--- a/src/commands/music/247.command.ts
+++ b/src/commands/music/247.command.ts
@@ -1,8 +1,22 @@
-import { Command, createBooleanOption, Declare, type GuildCommandContext, LocalesT, Middlewares, Options } from "seyfert";
+import {
+    type AllGuildVoiceChannels,
+    Command,
+    createBooleanOption,
+    Declare,
+    type GuildCommandContext,
+    type GuildMember,
+    LocalesT,
+    Middlewares,
+    Options,
+    type VoiceState,
+} from "seyfert";
 import { ApplicationIntegrationType, InteractionContextType } from "seyfert/lib/types/index.js";
 import { type AutoplayState, StelleCategory } from "#stelle/types";
 import { StelleMusic } from "#stelle/utils/data/constants.js";
 import { StelleOptions } from "#stelle/utils/decorator.js";
+import { TrackOps } from "#stelle/utils/functions/internal/track.js";
+import { joinVoiceChannel } from "#stelle/utils/functions/manager/voice.js";
+import { Sessions } from "#stelle/utils/manager/sessions.js";
 
 const options = {
     autopause: createBooleanOption({
@@ -24,20 +38,53 @@ const options = {
     aliases: ["twentyfourseven", "alwaysonline", "alwayson"],
 })
 @StelleOptions({ category: StelleCategory.Music, cooldown: 10 })
-@Middlewares(["checkNodes", "checkPlayer", "checkVoiceChannel", "checkVoicePermissions", "checkBotVoiceChannel"])
+@Middlewares(["checkNodes", "checkVoiceChannel", "checkVoicePermissions", "checkBotVoiceChannel"])
 @LocalesT("locales.twentyforseven.name", "locales.twentyforseven.description")
 @Options(options)
 export default class TwentyFourSevenCommand extends Command {
-    override async run(ctx: GuildCommandContext<typeof options, "checkPlayer">) {
+    override async run(ctx: GuildCommandContext<typeof options>) {
+        const { client, member, channelId, guildId } = ctx;
         const { messages } = await ctx.locale();
 
-        const { player } = ctx.metadata.checkPlayer;
+        const me: GuildMember | null = await ctx.me().catch((): null => null);
+        if (!me) return;
 
-        await player.data.set("is247", !(await player.data.get("is247")));
+        const state: VoiceState | null = await member.voice().catch((): null => null);
+        const voice: AllGuildVoiceChannels | null | undefined = await state?.channel().catch((): null => null);
+        if (!voice) return;
+
+        const { defaultVolume } = await client.database.players.get(guildId);
+
+        // Create-or-get: `createPlayer` returns the existing player when one already exists for the guild, so 24/7 can
+        // be toggled with or without an active player — no `checkPlayer` guard needed.
+        const player = client.manager.createPlayer({
+            guildId,
+            voiceId: voice.id,
+            textId: channelId,
+            volume: defaultVolume,
+            selfMute: false,
+            selfDeaf: true,
+        });
+
+        await joinVoiceChannel(player, voice, me);
+
+        if (!(await player.data.get("localeString"))) await player.data.set("localeString", await ctx.localeString());
+        if (!(await player.data.get("me"))) await player.data.set("me", TrackOps.requesterFn(client.me));
+
+        const is247: boolean = !(await player.data.get("is247"));
+
+        await player.data.set("is247", is247);
         await player.data.set("isAutoPause", ctx.options.autopause ?? false);
 
-        const is247: boolean = (await player.data.get("is247"))!;
         const autoPause: boolean = (await player.data.get("isAutoPause"))!;
+
+        // Persist right away so the 24/7 autoreconnect (which reads is247 from the session on playerDestroy) reflects
+        // the new value even before the next player update writes it.
+        if (client.config.sessions.enabled) await Sessions.save(player);
+
+        // Turning 24/7 off on an idle player: leave the channel instead of lingering. `destroy()` uses reason
+        // `Player-Stop`, so the autoreconnect branch never triggers here.
+        if (!is247 && !player.playing && !player.queue.current && !player.queue.tracks.length) await player.destroy();
 
         /**
          *

--- a/src/config/default.config.ts
+++ b/src/config/default.config.ts
@@ -73,6 +73,7 @@ export default createConfig({
     twentyfourseven: {
         autoPause: true,
         is247: false,
+        autoReconnect: true,
     },
     playlists: {
         userLimit: 25,

--- a/src/lavalink/player/destroy.event.ts
+++ b/src/lavalink/player/destroy.event.ts
@@ -1,13 +1,58 @@
-import { EventNames } from "hoshimi";
-import { type AllChannels, LogLevels } from "seyfert";
+import { DestroyReasons, EventNames } from "hoshimi";
+import { type AllChannels, LogLevels, type UsingClient } from "seyfert";
+import type { SessionJson } from "#stelle/types";
 import { PanelOps } from "#stelle/utils/functions/manager/panel.js";
 import { PlayerOps } from "#stelle/utils/functions/manager/player.js";
 import { createLavalinkEvent } from "#stelle/utils/manager/events.js";
 import { Sessions } from "#stelle/utils/manager/sessions.js";
 
+/**
+ *
+ * Recreate a 24/7 player from its persisted session and rejoin its voice channel. Used when the bot is kicked out
+ * of voice while 24/7 is enabled: instead of tearing down, it comes back. Mirrors `resumeListener`'s restore, but
+ * connects fresh (the old voice state is gone) rather than patching a live one.
+ * @param {UsingClient} client The client instance.
+ * @param {SessionJson} session The persisted session to restore from.
+ * @returns {Promise<void>} A promise that resolves once the player is reconnected.
+ */
+async function reconnect(client: UsingClient, session: SessionJson): Promise<void> {
+    const player = client.manager.createPlayer({ ...session.options });
+
+    await player.connect();
+
+    if (session.messageId) await player.data.set("messageId", session.messageId);
+    if (session.enabledAutoplay) await player.data.set("enabledAutoplay", session.enabledAutoplay);
+    if (session.me) await player.data.set("me", session.me);
+    if (session.localeString) await player.data.set("localeString", session.localeString);
+    if (session.lyricsId) await player.data.set("lyricsId", session.lyricsId);
+    if (session.lyricsEnabled) await player.data.set("lyricsEnabled", session.lyricsEnabled);
+    if (session.is247) await player.data.set("is247", session.is247);
+    if (session.isAutoPause) await player.data.set("isAutoPause", session.isAutoPause);
+    if (session.isRequestChannel) await player.data.set("isRequestChannel", session.isRequestChannel);
+
+    client.debug(LogLevels.Info, `[Lavalink] 24/7 autoreconnect | guild: ${session.guildId} | voice: ${session.options.voiceId}`);
+}
+
 export default createLavalinkEvent({
     name: EventNames.PlayerDestroy,
-    async run(client, player): Promise<void> {
+    async run(client, player, reason): Promise<void> {
+        // 24/7 autoreconnect: a forced voice disconnect (kick / channel deleted / moved out) destroys the player with
+        // `VoiceChannelLeft`. When 24/7 is on, recreate it from the session and rejoin instead of tearing down. is247
+        // comes from the session because `player.data` is already cleared by the time this fires.
+        const session: SessionJson | undefined = Sessions.get<SessionJson>(player.guildId);
+        const is247: boolean = session?.is247 ?? client.config.twentyfourseven.is247;
+
+        if (
+            session &&
+            is247 &&
+            reason === DestroyReasons.VoiceChannelLeft &&
+            client.config.twentyfourseven.autoReconnect &&
+            client.config.sessions.enabled
+        ) {
+            await reconnect(client, session);
+            return;
+        }
+
         Sessions.delete(player.guildId);
 
         const textId: string | undefined = player.textId ?? player.options.textId;

--- a/src/lavalink/player/update.event.ts
+++ b/src/lavalink/player/update.event.ts
@@ -1,8 +1,5 @@
-import type { PlayerJSON } from "hoshimi";
-import { EventNames } from "hoshimi";
+import { EventNames, type PlayerJSON } from "hoshimi";
 import { LogLevels } from "seyfert";
-import type { NonOptionsNode, SessionJson, TrackUser } from "#stelle/types";
-import { UtilsOps } from "#stelle/utils/functions/internal/utils.js";
 import { createLavalinkEvent } from "#stelle/utils/manager/events.js";
 import { Sessions } from "#stelle/utils/manager/sessions.js";
 
@@ -22,48 +19,11 @@ export default createLavalinkEvent({
             oldPlayer.node.id !== newPlayerJson.node.id ||
             oldPlayer.node.sessionId !== newPlayerJson.node.sessionId
         ) {
-            if (newPlayerJson.queue?.current) newPlayerJson.queue.current.userData = {};
-
-            const newJson = UtilsOps.omit(newPlayerJson, [
-                "ping",
-                "createdTimestamp",
-                "lastPositionUpdate",
-                "paused",
-                "playing",
-                "queue",
-                "filters",
-                "node",
-            ]);
-
-            const node: NonOptionsNode = UtilsOps.omit(newPlayerJson.node, ["options"]);
-
-            const messageId: string | undefined = await newPlayer.data.get("messageId");
-            const enabledAutoplay: boolean | undefined = await newPlayer.data.get("enabledAutoplay");
-            const localeString: string | undefined = await newPlayer.data.get("localeString");
-            const me: TrackUser | undefined = await newPlayer.data.get("me");
-            const lyricsId: string | undefined = await newPlayer.data.get("lyricsId");
-            const lyricsEnabled: boolean | undefined = await newPlayer.data.get("lyricsEnabled");
-            const is247: boolean | undefined = await newPlayer.data.get("is247");
-            const isAutoPause: boolean | undefined = await newPlayer.data.get("isAutoPause");
-            const isRequestChannel: boolean | undefined = await newPlayer.data.get("isRequestChannel");
-
-            Sessions.set<SessionJson>(newPlayer.guildId, {
-                ...newJson,
-                messageId,
-                enabledAutoplay,
-                localeString,
-                me,
-                lyricsId,
-                lyricsEnabled,
-                is247,
-                isAutoPause,
-                isRequestChannel,
-                node,
-            });
+            await Sessions.save(newPlayer);
 
             client.debug(
                 LogLevels.Debug,
-                `[Lavalink] Session updated | guild: ${newPlayer.guildId} | node: ${node.id} | voice: ${newJson.voiceId} | text: ${newJson.textId}`,
+                `[Lavalink] Session updated | guild: ${newPlayer.guildId} | node: ${newPlayer.node.id} | voice: ${newPlayer.voiceId} | text: ${newPlayer.textId}`,
             );
         }
     },

--- a/src/structures/types/client/configuration.ts
+++ b/src/structures/types/client/configuration.ts
@@ -178,6 +178,12 @@ interface TwentyFourSeven {
      * @default true
      */
     autoPause: boolean;
+    /**
+     * Whether to automatically reconnect a 24/7 player when the bot is disconnected from the voice channel.
+     * @type {boolean}
+     * @default true
+     */
+    autoReconnect: boolean;
 }
 
 interface Playlists {

--- a/src/structures/utils/listeners/node/resumeListener.ts
+++ b/src/structures/utils/listeners/node/resumeListener.ts
@@ -1,4 +1,4 @@
-import type { LavalinkPlayer, NodeStructure } from "hoshimi";
+import { type LavalinkPlayer, type NodeStructure, StorageError } from "hoshimi";
 import { LogLevels, type UsingClient } from "seyfert";
 import type { SessionJson } from "#stelle/types";
 import { Sessions } from "#stelle/utils/manager/sessions.js";
@@ -16,49 +16,60 @@ export async function resumeListener(client: UsingClient, node: NodeStructure, p
     if (!client.config.sessions.enabled) return;
 
     for (const data of players) {
-        const session: SessionJson | undefined = Sessions.get<SessionJson>(data.guildId);
-        if (!session) continue;
+        // Resume each guild in isolation: a failure restoring one player must not abort the rest (or crash the process).
+        try {
+            const session: SessionJson | undefined = Sessions.get<SessionJson>(data.guildId);
+            if (!session) continue;
 
-        if (!data.state.connected) {
-            Sessions.delete(data.guildId);
-            continue;
+            if (!data.state.connected) {
+                Sessions.delete(data.guildId);
+                continue;
+            }
+
+            const player = client.manager.createPlayer({
+                ...session.options,
+                guildId: data.guildId,
+                volume: data.volume,
+                node: node.id,
+            });
+
+            if (session.messageId) await player.data.set("messageId", session.messageId);
+            if (session.enabledAutoplay) await player.data.set("enabledAutoplay", session.enabledAutoplay);
+            if (session.me) await player.data.set("me", session.me);
+            if (session.localeString) await player.data.set("localeString", session.localeString);
+            if (session.lyricsId) await player.data.set("lyricsId", session.lyricsId);
+            if (session.lyricsEnabled) await player.data.set("lyricsEnabled", session.lyricsEnabled);
+            if (session.is247) await player.data.set("is247", session.is247);
+            if (session.isAutoPause) await player.data.set("isAutoPause", session.isAutoPause);
+            if (session.isRequestChannel) await player.data.set("isRequestChannel", session.isRequestChannel);
+
+            player.voice.patch({ ...data.voice });
+
+            await player.connect();
+
+            Object.assign(player.filterManager, { data: data.filters });
+
+            // An idle player (e.g. a 24/7 bot with no queue) has no stored queue to sync: hoshimi throws a
+            // StorageError in that case, which is expected here. Anything else is logged to the debugger rather than
+            // aborting the rest of this player's resume.
+            await player.queue.utils.sync({ override: true, syncCurrent: false }).catch((error: unknown): void => {
+                if (!(error instanceof StorageError))
+                    client.debug(LogLevels.Error, `[Lavalink] Queue sync failed | guild: ${player.guildId} | error: ${error}`);
+            });
+
+            if (data.track) player.queue.current = await player.queue.utils.build(data.track, session.me);
+
+            Object.assign(player, {
+                lastPosition: data.state.position,
+                lastPositionChange: Date.now(),
+                paused: data.paused,
+                playing: !data.paused && !!data.track,
+                loop: session.loop,
+            });
+
+            client.debug(LogLevels.Debug, `[Lavalink] Player resumed | node: ${node.id} | guild: ${player.guildId}`);
+        } catch (error) {
+            client.logger.error(`[Lavalink] Resume failed | node: ${node.id} | guild: ${data.guildId} | error: ${error}`);
         }
-
-        const player = client.manager.createPlayer({
-            ...session.options,
-            guildId: data.guildId,
-            volume: data.volume,
-            node: node.id,
-        });
-
-        if (session.messageId) await player.data.set("messageId", session.messageId);
-        if (session.enabledAutoplay) await player.data.set("enabledAutoplay", session.enabledAutoplay);
-        if (session.me) await player.data.set("me", session.me);
-        if (session.localeString) await player.data.set("localeString", session.localeString);
-        if (session.lyricsId) await player.data.set("lyricsId", session.lyricsId);
-        if (session.lyricsEnabled) await player.data.set("lyricsEnabled", session.lyricsEnabled);
-        if (session.is247) await player.data.set("is247", session.is247);
-        if (session.isAutoPause) await player.data.set("isAutoPause", session.isAutoPause);
-        if (session.isRequestChannel) await player.data.set("isRequestChannel", session.isRequestChannel);
-
-        player.voice.patch({ ...data.voice });
-
-        await player.connect();
-
-        Object.assign(player.filterManager, { data: data.filters });
-
-        await player.queue.utils.sync({ override: true, syncCurrent: false });
-
-        if (data.track) player.queue.current = await player.queue.utils.build(data.track, session.me);
-
-        Object.assign(player, {
-            lastPosition: data.state.position,
-            lastPositionChange: Date.now(),
-            paused: data.paused,
-            playing: !data.paused && !!data.track,
-            loop: session.loop,
-        });
-
-        client.debug(LogLevels.Debug, `[Lavalink] Player resumed | node: ${node.id} | guild: ${player.guildId}`);
     }
 }

--- a/src/structures/utils/manager/sessions.ts
+++ b/src/structures/utils/manager/sessions.ts
@@ -1,7 +1,7 @@
-import type { NodeOptions } from "hoshimi";
+import type { NodeOptions, PlayerStructure } from "hoshimi";
 import MeowDB from "meowdb";
 import type { MakeRequired, RestOrArray } from "seyfert/lib/common/index.js";
-import type { StellePlayerJson } from "#stelle/types";
+import type { NonOptionsNode, SessionJson, StellePlayerJson } from "#stelle/types";
 import { StellePaths } from "#stelle/utils/data/constants.js";
 import { InvalidNodeSession } from "#stelle/utils/errors.js";
 import { ms } from "#stelle/utils/functions/internal/time.js";
@@ -102,6 +102,44 @@ export const Sessions = {
                 ...node,
                 sessionId: ids.get(node.id),
             };
+        });
+    },
+    /**
+     *
+     * Snapshot a player into its persisted session, so it can be recreated after a restart, node resume or a 24/7
+     * autoreconnect. Mirrors the shape read back by `resumeListener` and the destroy autoreconnect. Callers gate
+     * this on `config.sessions.enabled`.
+     * @param {PlayerStructure} player The player to persist.
+     * @returns {Promise<void>} A promise that resolves once the session is written.
+     */
+    async save(player: PlayerStructure): Promise<void> {
+        const json = player.toJSON();
+        if (json.queue?.current) json.queue.current.userData = {};
+
+        const base = UtilsOps.omit(json, [
+            "ping",
+            "createdTimestamp",
+            "lastPositionUpdate",
+            "paused",
+            "playing",
+            "queue",
+            "filters",
+            "node",
+        ]);
+        const node: NonOptionsNode = UtilsOps.omit(json.node, ["options"]);
+
+        this.set<SessionJson>(player.guildId, {
+            ...base,
+            messageId: await player.data.get("messageId"),
+            enabledAutoplay: await player.data.get("enabledAutoplay"),
+            localeString: await player.data.get("localeString"),
+            me: await player.data.get("me"),
+            lyricsId: await player.data.get("lyricsId"),
+            lyricsEnabled: await player.data.get("lyricsEnabled"),
+            is247: await player.data.get("is247"),
+            isAutoPause: await player.data.get("isAutoPause"),
+            isRequestChannel: await player.data.get("isRequestChannel"),
+            node,
         });
     },
 };


### PR DESCRIPTION
## What

Makes `/247` usable without an active player and adds a config-gated autoreconnect so a 24/7 bot comes back after being forced out of voice.

### `feat(247)`
- Drop the `checkPlayer` guard from `/247` and **create-or-get** the player in the command (`createPlayer` already returns an existing one). 24/7 can now be toggled with or without music — the bot joins the author's channel when idle.
- Turning 24/7 **off on an idle player** now leaves the channel (`destroy()` with reason `Player-Stop`, so it doesn't trip the autoreconnect).
- **Autoreconnect** (userland, race-free): on `playerDestroy` with reason `VoiceChannelLeft` + 24/7 on, recreate the player from its persisted session and rejoin. Gated by the new `twentyfourseven.autoReconnect` config flag (default `true`). `is247` is read from the session because `player.data` is cleared by the time `playerDestroy` fires.
- New `Sessions.save()` helper (extracted from the player-update handler and called on toggle) keeps the session fresh so the autoreconnect sees the current `is247`.

### `fix(lavalink)`
- Wrap each guild's resume in its own `try/catch` so one failing player no longer aborts the loop (previously it crashed the process).
- Tolerate the `StorageError` from queue sync when a player has no stored queue — expected for an idle 24/7 bot — and log any other sync error to the debugger instead of aborting that player's resume.

## Notes / known behavior
- Autoreconnect **rejoins idle**: the queue isn't persisted in the session, so a bot kicked mid-playback comes back without resuming the track.
- No backoff on the reconnect loop yet: if the bot lacks connect permission it will retry; `autoReconnect: false` is the escape hatch.
- Depends on `sessions.enabled` (consistent with the existing resume system).

## Testing
- Typecheck clean, 40 tests pass.
- Manually verified: toggling 24/7 idle/active, leave-on-disable, autoreconnect on kick, and a clean bot restart (resume no longer crashes on idle 24/7 sessions).
